### PR TITLE
parameterize helm chart variables at post-install-job

### DIFF
--- a/helm/templates/post-install-job.yaml
+++ b/helm/templates/post-install-job.yaml
@@ -9,12 +9,17 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
+  backoffLimit: {{ .Values.seed.backoffLimit }}
   template:
     metadata:
       name: {{ include "pkgsite.fullname" . }}-setup-db
       labels:
         {{- include "pkgsite.labels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       volumes:
         - name: seed

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -32,6 +32,7 @@ seed:
   packages:
   - std@latest
   - golang.org/x/tools@latest
+  backoffLimit:
 
 # default helm deployment values
 replicaCount: 1


### PR DESCRIPTION
Hello @cezarguimaraes ,
I would like to use your chart as a dependency to my project.
I needed to inject several parameters (i.e : imagePullSecrets, backoffLimit) to the seeddb job template so it would fit my project.
To my understanding this small change add 2 more generic configuration so it an be useful to all stakeholders as well.

Can you please consider merging this change ?
 
Best Regards :-)