### PR TITLE
Added post-upgrade helm hook to data insert job

### DIFF
--- a/helm/templates/post-install-job.yaml
+++ b/helm/templates/post-install-job.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "pkgsite.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:


### PR DESCRIPTION
PR:

This small change in the helm hooks will ensure that, whenever we add new modules to the seeds list, it will run on the upgrade of the helm chart, making the chart and database dynamic.

For more information:
https://helm.sh/docs/topics/charts_hooks/
